### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dotnet-core-desktop.yml
+++ b/.github/workflows/dotnet-core-desktop.yml
@@ -37,6 +37,8 @@
 # refer to https://github.com/microsoft/github-actions-for-desktop-apps
 
 name: .NET Core Desktop
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Pearl1981/unstop/security/code-scanning/1](https://github.com/Pearl1981/unstop/security/code-scanning/1)

To fix the issue, add a `permissions` block at the root level of the workflow file. This block will explicitly define the permissions for the `GITHUB_TOKEN`, limiting it to `contents: read`. This is sufficient for the actions used in the workflow, as they primarily require read access to the repository contents.

The `permissions` block should be added immediately after the `name` key (line 39) to apply to all jobs in the workflow. No additional changes are required for individual jobs unless specific permissions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
